### PR TITLE
feat: initialize reinput-auth-service with Spring Boot and Eureka integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ prod.env
 dev.env
 .env.dev
 .env.prod
+
+### application properties ###
+src/main/resources/application-dev.properties

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.4'
-	id 'io.spring.dependency-management' version '1.1.6'
+	id 'org.springframework.boot' version '3.4.1'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
-group = 'info'
+group = 'info.reinput'
 version = '0.0.1-SNAPSHOT'
 
 java {
@@ -59,8 +59,21 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//eureka
+	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+ext {
+	set('springCloudVersion', "2024.0.0")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'reinput'
+rootProject.name = 'reinput-auth-service'

--- a/src/main/java/info/reinput/ReinputAuthServiceApplication.java
+++ b/src/main/java/info/reinput/ReinputAuthServiceApplication.java
@@ -2,12 +2,14 @@ package info.reinput;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
 @SpringBootApplication
-public class ReinputApplication {
+@EnableDiscoveryClient
+public class ReinputAuthServiceApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(ReinputApplication.class, args);
+		SpringApplication.run(ReinputAuthServiceApplication.class, args);
 	}
 
 }

--- a/src/main/resources/application-dev.properties.example
+++ b/src/main/resources/application-dev.properties.example
@@ -1,0 +1,5 @@
+jwt.secret=your-jwt-secret-key-here
+jwt.accessToken.expiration=3600
+jwt.refreshToken.expiration=86400
+kakao.client.id=your-kakao-client-id
+kakao.client.secret=your-kakao-client-secret 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,25 @@
 spring:
+  profiles:
+    active: dev
+---
+server:
+  port: 0
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    instance-id: ${spring.application.name}:${spring.application.instance_id:${random.value}}
+
+spring:
   config:
     activate:
       on-profile: dev
+  application:
+    name: reinput-auth-service
   datasource:
     url: jdbc:h2:mem:reinput;MODE=MySQL
     username: sa

--- a/src/test/java/info/reinput/ReinputAuthServiceApplicationTests.java
+++ b/src/test/java/info/reinput/ReinputAuthServiceApplicationTests.java
@@ -4,10 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class ReinputApplicationTests {
-
+class ReinputAuthServiceApplicationTests {
 	@Test
 	void contextLoads() {
 	}
-
 }


### PR DESCRIPTION
# 1. PR 설명
- Updated project name to 'reinput-auth-service'
- Upgraded Spring Boot to version 3.4.1 and dependency management to 1.1.7
- Added application properties for development environment
- Introduced main application class for Spring Boot
- Configured Eureka client for service discovery
- Created example properties file for JWT and Kakao client configuration
- Updated application.yml to set active profile and Eureka settings
- Added basic test class for application context loading

# 2. 작업 내용

# 3. 연관 이슈
[RE-152]


[RE-152]: https://reinput.atlassian.net/browse/RE-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ