### PR TITLE
RE-171 Refactor application-dev.yml to use GitHub secrets for sensitive configurations

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,9 +5,9 @@ spring:
   application:
     name: reinput-auth-service
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: jdbc:mysql://${{ secrets.DB_HOST }}:${{ secrets.DB_PORT }}/${{ secrets.DB_NAME }}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${{ secrets.DB_USERNAME }}
+    password: ${{ secrets.DB_PASSWORD }}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -29,8 +29,8 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${KAKAO_CLIENT_ID}
-            client-secret: ${KAKAO_CLIENT_SECRET}
+            client-id: ${{ secrets.KAKAO_CLIENT_ID }}
+            client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
             redirect-uri: "http://api.reinput.info:8000/auth/oauth2/kakao/callback/v1"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
@@ -43,7 +43,7 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 jwt:
-  secret: ${JWT_SECRET}
+  secret: ${{ secrets.JWT_SECRET }}
   accessToken:
     expiration: 3600
   refreshToken:
@@ -55,8 +55,8 @@ springdoc:
     url: /member/v3/api-docs
     disable-swagger-default-url: true
     oauth:
-      client-id: ${KAKAO_CLIENT_ID}
-      client-secret: ${KAKAO_CLIENT_SECRET}
+      client-id: ${{ secrets.KAKAO_CLIENT_ID }}
+      client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
       scopes: account_email
       app-name: reinput-auth-service
     oauth2-redirect-url: "http://api.reinput.info:8000/member/swagger-ui/oauth2-redirect.html"


### PR DESCRIPTION
# 1. PR 설명
- Updated database connection settings to utilize GitHub secrets for DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, and DB_PASSWORD.
- Changed OAuth2 client credentials for Kakao to use GitHub secrets for KAKAO_CLIENT_ID and KAKAO_CLIENT_SECRET.
- Updated JWT secret to use GitHub secrets for JWT_SECRET.
- Ensured sensitive information is not hardcoded in the configuration file.


# 2. 작업 내용


# 3. 기타

- [RE-171]

[RE-171]: https://reinput.atlassian.net/browse/RE-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ