### PR TITLE
RE-171 Enhance application configuration to utilize environment variables for sensitive data

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,6 +49,11 @@ jobs:
               -e JWT_SECRET="${{ secrets.JWT_SECRET }}" \
               -e KAKAO_CLIENT_ID="${{ secrets.KAKAO_CLIENT_ID }}" \
               -e KAKAO_CLIENT_SECRET="${{ secrets.KAKAO_CLIENT_SECRET }}" \
+              -e DB_HOST="${{ secrets.DB_HOST }}" \
+              -e DB_PORT="${{ secrets.DB_PORT }}" \
+              -e DB_NAME="${{ secrets.DB_NAME }}" \
+              -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
+              -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
               ${{ env.ECR_REGISTRY }}/reinput/auth-service:latest
             
             docker ps | grep auth-service

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,9 +5,9 @@ spring:
   application:
     name: reinput-auth-service
   datasource:
-    url: jdbc:mysql://${{ secrets.DB_HOST }}:${{ secrets.DB_PORT }}/${{ secrets.DB_NAME }}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${{ secrets.DB_USERNAME }}
-    password: ${{ secrets.DB_PASSWORD }}
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
@@ -29,8 +29,8 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${{ secrets.KAKAO_CLIENT_ID }}
-            client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
             redirect-uri: "http://api.reinput.info:8000/auth/oauth2/kakao/callback/v1"
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
@@ -43,7 +43,7 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 jwt:
-  secret: ${{ secrets.JWT_SECRET }}
+  secret: ${JWT_SECRET}
   accessToken:
     expiration: 3600
   refreshToken:
@@ -55,8 +55,8 @@ springdoc:
     url: /member/v3/api-docs
     disable-swagger-default-url: true
     oauth:
-      client-id: ${{ secrets.KAKAO_CLIENT_ID }}
-      client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
+      client-id: ${KAKAO_CLIENT_ID}
+      client-secret: ${KAKAO_CLIENT_SECRET}
       scopes: account_email
       app-name: reinput-auth-service
     oauth2-redirect-url: "http://api.reinput.info:8000/member/swagger-ui/oauth2-redirect.html"


### PR DESCRIPTION

# 1. PR 설명
- Updated .github/workflows/cd.yml to include database environment variables (DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD) for the auth-service.
- Refactored application-dev.yml to replace GitHub secrets with environment variable references for database and Kakao OAuth2 client credentials.
- Ensured sensitive information is not hardcoded, improving security and maintainability.


# 2. 작업 내용


# 3. 기타

- [RE-171]


[RE-171]: https://reinput.atlassian.net/browse/RE-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ